### PR TITLE
Pass endpoint dependencies to Jinja context via request.state

### DIFF
--- a/fasthx/main.py
+++ b/fasthx/main.py
@@ -139,6 +139,7 @@ class Jinja:
         """
 
         def render(result: Any, *, context: dict[str, Any], request: Request) -> HTMLResponse:
+            request.state.depends = context
             return self.templates.TemplateResponse(name=template_name, request=request, context=result)
 
         return hx(render, no_data=no_data)


### PR DESCRIPTION
Related to #4

What is `request.state` and why am I using it?

https://github.com/encode/starlette/blob/433da65fc1431754dae0c3c87290b0421aa4a6f9/starlette/datastructures.py#L680-L685

Request State documentation says: `An object that can be used to store arbitrary state.`

I saw many implementations using the `request.state` to carry database sessions, current user, client sessions, etc. I think it's the best way to pass endpoint dependencies to the Jinja context without affecting anything.