### PR TITLE
Fixed request context bug, silenced Ruff warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# IDE
+.vscode


### PR DESCRIPTION
Fixing the following error:

```
    return self.templates.TemplateResponse(name=template_name, request=request, context=result)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Jinja2Templates.TemplateResponse() got an unexpected keyword argument 'request'
```

The error is due to how the `TemplateResponse` is being constructed in the render function within the `Jinja` class. Specifically, the error arises because the `TemplateResponse` method is being called with an incorrect argument: `request=request`. The request should be part of the context dictionary, not passed as a separate argument.

Also fixed some obvious Ruff warnings and silenced the rest non-critical comment related warnings.