### PR TITLE
Error rendering

### DIFF
--- a/docs/api/jinja.md
+++ b/docs/api/jinja.md
@@ -12,6 +12,10 @@
     options:
         show_root_heading: true
 
+## ::: fasthx.JinjaPath
+    options:
+        show_root_heading: true
+
 ## ::: fasthx.JinjaContextFactory
     members:
         - __call__

--- a/fasthx/__init__.py
+++ b/fasthx/__init__.py
@@ -4,6 +4,7 @@ from .dependencies import DependsHXRequest as DependsHXRequest
 from .dependencies import get_hx_request as get_hx_request
 from .jinja import Jinja as Jinja
 from .jinja import JinjaContext as JinjaContext
+from .jinja import JinjaPath as JinjaPath
 from .jinja import TemplateHeader as TemplateHeader
 from .typing import HTMLRenderer as HTMLRenderer
 from .typing import JinjaContextFactory as JinjaContextFactory

--- a/fasthx/jinja.py
+++ b/fasthx/jinja.py
@@ -390,7 +390,7 @@ class Jinja:
             context=jinja_context,
             request=request,
         )
-        return result.body.decode(result.charset)
+        return bytes(result.body).decode(result.charset)
 
     def _resolve_template_name(
         self,

--- a/fasthx/jinja.py
+++ b/fasthx/jinja.py
@@ -235,7 +235,7 @@ class TemplateHeader:
                 {k.lower(): v for k, v in self.templates.items()},
             )
 
-    def get_component_id(self, request: Request, error: Exception | None = None) -> str:
+    def get_component_id(self, request: Request, error: Exception | None) -> str:
         """
         Returns the name of the template that was requested by the client.
 

--- a/fasthx/typing.py
+++ b/fasthx/typing.py
@@ -77,12 +77,29 @@ class RequestComponentSelector(Protocol):
     The protocol is runtime-checkable, so it can be used in `isinstance()`, `issubclass()` calls.
     """
 
-    def get_component_id(self, request: Request) -> str:
+    def get_component_id(self, request: Request, error: Exception | None = None) -> str:
         """
         Returns the identifier of the component that was requested by the client.
 
+        The caller should ensure that `error` will be the exception that was raised by the
+        route or `None` if the route returned normally.
+
+        If an implementation can not or does not want to handle route errors, then the method
+        should re-raise the received exception. Example:
+
+        ```python
+        class MyComponentSelector:
+            def get_component_id(self, request: Request, error: Exception | None = None) -> str:
+                if error is not None:
+                    raise error
+
+                ...
+        ```
+
         Raises:
             KeyError: If the component couldn't be identified.
+            Exception: The received `error` argument if it was not `None` and the implementation
+                can not handle route errors.
         """
         ...
 

--- a/fasthx/typing.py
+++ b/fasthx/typing.py
@@ -77,7 +77,7 @@ class RequestComponentSelector(Protocol):
     The protocol is runtime-checkable, so it can be used in `isinstance()`, `issubclass()` calls.
     """
 
-    def get_component_id(self, request: Request, error: Exception | None = None) -> str:
+    def get_component_id(self, request: Request, error: Exception | None) -> str:
         """
         Returns the identifier of the component that was requested by the client.
 
@@ -89,7 +89,7 @@ class RequestComponentSelector(Protocol):
 
         ```python
         class MyComponentSelector:
-            def get_component_id(self, request: Request, error: Exception | None = None) -> str:
+            def get_component_id(self, request: Request, error: Exception | None) -> str:
                 if error is not None:
                     raise error
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fasthx"
-version = "1.1.1"
+version = "2.0.0-rc1"
 description = "FastAPI data APIs with HTMX support."
 authors = ["Peter Volf <do.volfp@gmail.com>"]
 readme = "README.md"
@@ -13,15 +13,15 @@ typing-extensions = ">=4.5.0"
 
 [tool.poetry.group.dev.dependencies]
 httpx = "^0.26.0"
-jinja2 = "^3.1.3"
-mkdocs-material = "^9.5.29"
-mkdocstrings = {extras = ["python"], version = "^0.25.1"}
-mypy = "^1.10.0"
+jinja2 = "^3.1.4"
+mkdocs-material = "^9.5.32"
+mkdocstrings = {extras = ["python"], version = "^0.25.2"}
+mypy = "^1.11.1"
 poethepoet = "^0.27.0"
-pytest = "^8.0.1"
+pytest = "^8.3.2"
 pytest-random-order = "^1.1.1"
-ruff = "^0.5.0"
-uvicorn = "^0.27.1"
+ruff = "^0.6.2"
+uvicorn = "^0.30.6"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/templates/hello-world.jinja
+++ b/tests/templates/hello-world.jinja
@@ -1,0 +1,1 @@
+Hello World!

--- a/tests/templates/random_number.jinja
+++ b/tests/templates/random_number.jinja
@@ -1,1 +1,0 @@
-<h1>{{random_number}}</h1>

--- a/tests/test_core_decorators.py
+++ b/tests/test_core_decorators.py
@@ -21,8 +21,22 @@ async def async_render_user_list(result: list[User], *, context: dict[str, Any],
     return render_user_list(result, context=context, request=request)
 
 
+class DataError(Exception):
+    def __init__(self, message: str, response: Response) -> None:
+        self.message = message
+        # Highlight how to set the response code for a route that has error rendering.
+        response.status_code = 499
+
+
+def render_data_error(result: Exception, *, context: dict[str, Any], request: Request) -> str:
+    if isinstance(result, DataError):
+        return f'<DataError message="{result.message}" />'
+
+    raise result
+
+
 @pytest.fixture
-def hx_app() -> FastAPI:
+def hx_app() -> FastAPI:  # noqa: C901
     app = FastAPI()
 
     @app.get("/")
@@ -36,9 +50,42 @@ def hx_app() -> FastAPI:
         response.headers["test-header"] = "exists"
         return users
 
-    @app.get("/htmx-only")  # type: ignore # TODO: figure out why mypy doesn't see the correct type.
+    # There's a strange mypy issue here, it finds errors for the routes that defined later,
+    # regardless of the order. It seems it fails to resolve and match generic types.
+
+    @app.get("/htmx-only")  # type: ignore
     @hx(async_render_user_list, no_data=True)
     async def htmx_only(random_number: DependsRandomNumber) -> list[User]:
+        return users
+
+    @app.get("/error/{kind}")  # type: ignore
+    @hx(render_user_list, render_error=render_data_error)
+    def error_in_route(kind: str, response: Response) -> list[User]:
+        if kind == "data":
+            raise DataError("test-message", response)
+        elif kind == "value":
+            raise ValueError("Value error was requested.")
+
+        return users
+
+    @app.get("/error-no-data/{kind}")  # type: ignore
+    @hx(render_user_list, render_error=render_data_error, no_data=True)
+    def error_in_route_no_data(kind: str, response: Response) -> list[User]:
+        if kind == "data":
+            raise DataError("test-message", response)
+        elif kind == "value":
+            raise ValueError("Value error was requested.")
+
+        return users
+
+    @app.get("/error-page/{kind}")  # type: ignore
+    @page(render_user_list, render_error=render_data_error)
+    def error_in_route_page(kind: str, response: Response) -> list[User]:
+        if kind == "data":
+            raise DataError("test-message", response)
+        elif kind == "value":
+            raise ValueError("Value error was requested.")
+
         return users
 
     return app
@@ -46,7 +93,7 @@ def hx_app() -> FastAPI:
 
 @pytest.fixture
 def hx_client(hx_app: FastAPI) -> TestClient:
-    return TestClient(hx_app)
+    return TestClient(hx_app, raise_server_exceptions=False)
 
 
 @pytest.mark.parametrize(
@@ -83,3 +130,30 @@ def test_hx_and_page(
     assert result == expected
 
     assert all((response.headers.get(key) == value) for key, value in response_headers.items())
+
+
+@pytest.mark.parametrize(
+    ("route", "headers", "status", "expected"),
+    (
+        ("/error/data", {"HX-Request": "true"}, 499, '<DataError message="test-message" />'),
+        ("/error/data", None, 500, None),  # No rendering, internal server error
+        ("/error/value", {"HX-Request": "true"}, 500, None),  # No rendering for value route
+        ("/error-no-data/data", {"HX-Request": "true"}, 499, '<DataError message="test-message" />'),
+        ("/error-no-data/data", None, 400, None),  # No data, bad request
+        ("/error-no-data/value", {"HX-Request": "true"}, 500, None),  # No rendering for value route
+        ("/error-page/data", {"HX-Request": "true"}, 499, '<DataError message="test-message" />'),
+        ("/error-page/data", None, 499, '<DataError message="test-message" />'),  # Rendering non-HX request
+        ("/error-page/value", {"HX-Request": "true"}, 500, None),  # No rendering for value route
+    ),
+)
+def test_hx_and_page_error_rendering(
+    hx_client: TestClient,
+    route: str,
+    headers: dict[str, str] | None,
+    status: int,
+    expected: str | None,
+) -> None:
+    response = hx_client.get(route, headers=headers)
+    assert response.status_code == status
+    if expected is not None:
+        assert response.text == expected

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -107,7 +107,7 @@ def jinja_app() -> FastAPI:
             "X-Error-Component",
             {},
             default="hello-world.jinja",
-            error=RenderedError,
+            error=(RenderedError, TypeError, ValueError),  # Test error tuple
         ),
     )
     def error_page(response: Response) -> None:

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, Response
 from fastapi.templating import Jinja2Templates
 from fastapi.testclient import TestClient
 
-from fasthx import Jinja, JinjaContext, TemplateHeader
+from fasthx import Jinja, JinjaContext, JinjaPath, TemplateHeader
 
 from .data import (
     DependsRandomNumber,
@@ -20,6 +20,18 @@ from .data import (
     user_list_json,
     users,
 )
+
+
+class RenderedError(Exception):
+    def __init__(self, data: dict[str, Any], *, response: Response) -> None:
+        super().__init__("Data validation failed.")
+
+        # Pattern for setting the response status code for error rendering responses.
+        response.status_code = 456
+
+        # Pattern to make the data available in Jinja rendering contexts. Not used in tests.
+        for key, value in data.items():
+            setattr(self, key, value)
 
 
 @pytest.fixture
@@ -51,6 +63,7 @@ def jinja_app() -> FastAPI:
             {
                 "header": "h1.jinja",
                 "paragraph": "p.jinja",
+                "hello-world": JinjaPath("hello-world.jinja"),
             },
             default="span.jinja",
         ),
@@ -72,6 +85,33 @@ def jinja_app() -> FastAPI:
     )
     def header_with_no_default() -> User:
         return billy
+
+    @app.get("/error")
+    @jinja.hx(
+        TemplateHeader("X-Component", {}),  # No rendering if there's no exception.
+        error_template=TemplateHeader(
+            "X-Error-Component",
+            {},
+            default="hello-world.jinja",
+            error=RenderedError,
+        ),
+        no_data=True,
+    )
+    def error(response: Response) -> None:
+        raise RenderedError({"a": 1, "b": 2}, response=response)
+
+    @app.get("/error-page")
+    @jinja.page(
+        TemplateHeader("X-Component", {}),  # No rendering if there's no exception.
+        error_template=TemplateHeader(
+            "X-Error-Component",
+            {},
+            default="hello-world.jinja",
+            error=RenderedError,
+        ),
+    )
+    def error_page(response: Response) -> None:
+        raise RenderedError({"a": 1, "b": 2}, response=response)
 
     return app
 
@@ -103,6 +143,8 @@ def jinja_client(jinja_app: FastAPI) -> TestClient:
         ("/htmx-or-data/1", None, 200, billy_json, {}),
         ("/htmx-or-data/2", {"HX-Request": "true"}, 200, billy_html_span, {}),
         ("/htmx-or-data/3", {"HX-Request": "true", "X-Component": "header"}, 200, billy_html_header, {}),
+        # JinjaPath test (decorator prefix not used).
+        ("/htmx-or-data/3", {"HX-Request": "true", "X-Component": "hello-world"}, 200, "Hello World!", {}),
         (
             "/htmx-or-data/3",
             {"HX-Request": "true", "X-Component": "HeAdEr"},  # Test case-sensitivity.
@@ -144,6 +186,10 @@ def jinja_client(jinja_app: FastAPI) -> TestClient:
         ("/htmx-only", {"HX-Request": "true"}, 200, user_list_html, {}),
         ("/htmx-only", None, 400, "", {}),
         ("/htmx-only", {"HX-Request": "false"}, 400, "", {}),
+        # hx error rendering
+        ("/error", {"HX-Request": "true"}, 456, "Hello World!", {}),
+        # page error rendering
+        ("/error-page", None, 456, "Hello World!", {}),
     ),
 )
 def test_jinja(


### PR DESCRIPTION
The PR contains breaking changes, so the new release that'll officially get these features will be `2.0`.

Features:

- Both the core (`hx()` and `page()`) decorators and the Jinja integration got support for error rendering. Fixes #28.
- Response status code and background job are preserved (if set on the `Response` dependency for example in a route). Fixes #26 #27.
- Added a `JinjaPath` utility, see docs for details.

Breaking changes:

- To support error rendering, the `RequestComponentSelector` protocol got a second argument (`error: Exception | None`).
- The internals of `Jinja` changed slightly.

How to upgrade:

- If you have custom `RequestComponentSelector` implementations, then please add the new argument to the `get_component_id()` method. Well-behaved `RequestComponentSelector`s that don's support error rendering should reraise the received error if it's not `None` (although not doing so will not break anything as result and errors are clearly separated in `Jinja` and the core decorators don't rely on this protocol).
- If you've overridden any of the protected methods of `Jinja`, please go through this PR so you can upgrade your custom implementation.