### PR TITLE
Fixed: Page routes cannot have a Request dependency

### DIFF
--- a/tests/test_core_decorators.py
+++ b/tests/test_core_decorators.py
@@ -44,6 +44,16 @@ def hx_app() -> FastAPI:  # noqa: C901
     def index(random_number: DependsRandomNumber) -> list[User]:
         return users
 
+    @app.get("/page-request-dependency-args")
+    @page(render_user_list)
+    def prd_a(random_number: DependsRandomNumber, request: Request) -> list[User]:
+        return users
+
+    @app.get("/page-request-dependency-kwargs")
+    @page(render_user_list)
+    def prd_kw(random_number: DependsRandomNumber, *, request: Request) -> list[User]:
+        return users
+
     @app.get("/htmx-or-data")
     @hx(render_user_list)
     def htmx_or_data(random_number: DependsRandomNumber, response: Response) -> list[User]:
@@ -103,6 +113,8 @@ def hx_client(hx_app: FastAPI) -> TestClient:
         ("/", {"HX-Request": "true"}, 200, user_list_html, {}),
         ("/", None, 200, user_list_html, {}),
         ("/", {"HX-Request": "false"}, 200, user_list_html, {}),
+        ("/page-request-dependency-args", None, 200, user_list_html, {}),
+        ("/page-request-dependency-kwargs", None, 200, user_list_html, {}),
         # hx() - returns JSON for non-HTMX requests.
         ("/htmx-or-data", {"HX-Request": "true"}, 200, user_list_html, {"test-header": "exists"}),
         ("/htmx-or-data", None, 200, user_list_json, {"test-header": "exists"}),

--- a/tests/test_core_decorators.py
+++ b/tests/test_core_decorators.py
@@ -56,7 +56,7 @@ def hx_app() -> FastAPI:  # noqa: C901
 
     @app.get("/htmx-or-data")
     @hx(render_user_list)
-    def htmx_or_data(random_number: DependsRandomNumber, response: Response) -> list[User]:
+    def htmx_or_data(random_number: DependsRandomNumber, response: Response, request: Request) -> list[User]:
         response.headers["test-header"] = "exists"
         return users
 
@@ -65,7 +65,7 @@ def hx_app() -> FastAPI:  # noqa: C901
 
     @app.get("/htmx-only")  # type: ignore
     @hx(async_render_user_list, no_data=True)
-    async def htmx_only(random_number: DependsRandomNumber) -> list[User]:
+    async def htmx_only(random_number: DependsRandomNumber, *, request: Request) -> list[User]:
         return users
 
     @app.get("/error/{kind}")  # type: ignore


### PR DESCRIPTION
Page routes cannot have a Request dependency injected.
I think because fastAPI cannot handle the same dependency being injected twice.
This is not an issue for the hx routes because they use a header, so the Request object does not end up being injected.

This PR solves this problem by using the existing Request object from the function signature if it's there, otherwise adding it like before.

This should have no impact on existing code as far as I can tell.