### PR TITLE
Workaround for a FastAPI dependency resolution bug

### DIFF
--- a/fasthx/core_decorators.py
+++ b/fasthx/core_decorators.py
@@ -1,9 +1,9 @@
 import inspect
 from collections.abc import Callable
 from functools import wraps
-from typing import Coroutine, cast
+from typing import Coroutine
 
-from fastapi import HTTPException, Request, Response, status
+from fastapi import HTTPException, Response, status
 from fastapi.responses import HTMLResponse
 
 from .dependencies import DependsHXRequest, DependsPageRequest
@@ -57,12 +57,7 @@ def hx(
                 return result
 
             response = get_response(kwargs)
-            rendered = await execute_maybe_sync_func(
-                renderer,
-                result,
-                context=kwargs,
-                request=cast(Request, __hx_request),
-            )
+            rendered = await execute_maybe_sync_func(renderer, result, context=kwargs, request=__hx_request)
 
             return (
                 HTMLResponse(
@@ -120,10 +115,7 @@ def page(
 
             response = get_response(kwargs)
             rendered = await execute_maybe_sync_func(
-                renderer,
-                result,
-                context=kwargs,
-                request=cast(Request, __page_request),
+                renderer, result, context=kwargs, request=__page_request
             )
             return (
                 HTMLResponse(

--- a/fasthx/dependencies.py
+++ b/fasthx/dependencies.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Annotated, Any, TypeAlias
+from typing import TYPE_CHECKING, Annotated, Any, TypeAlias
 
 from fastapi import Depends, Header, Request
 
@@ -32,12 +32,16 @@ def get_page_request(request: Request) -> RequestAlias:
     return request
 
 
-DependsHXRequest = Annotated[RequestAlias | Request | None, Depends(get_hx_request)]
-"""Annotated type (dependency) for `get_hx_request()` for FastAPI."""
+if TYPE_CHECKING:
+    DependsHXRequest: TypeAlias = Request | None
+    DependsPageRequest: TypeAlias = Request
+else:
+    DependsHXRequest = Annotated[RequestAlias | Request | None, Depends(get_hx_request)]
+    """Annotated type (dependency) for `get_hx_request()` for FastAPI."""
 
-DependsPageRequest = Annotated[RequestAlias | Request, Depends(get_page_request)]
-"""
-Annotated `Request` dependency alias.
+    DependsPageRequest = Annotated[RequestAlias | Request, Depends(get_page_request)]
+    """
+    Annotated `Request` dependency alias.
 
-Workaround for this FastAPI bug: https://github.com/fastapi/fastapi/discussions/12403
-"""
+    Workaround for this FastAPI bug: https://github.com/fastapi/fastapi/discussions/12403
+    """

--- a/fasthx/dependencies.py
+++ b/fasthx/dependencies.py
@@ -1,9 +1,22 @@
-from typing import Annotated
+from collections.abc import Mapping
+from typing import Annotated, Any, TypeAlias
 
 from fastapi import Depends, Header, Request
 
+RequestAlias: TypeAlias = Mapping[str, Any]
+"""
+Alias for `Request` arguments.
 
-def get_hx_request(request: Request, hx_request: Annotated[str | None, Header()] = None) -> Request | None:
+Workaround for this FastAPI bug: https://github.com/fastapi/fastapi/discussions/12403.
+And here's a FastAPI bugfix: https://github.com/fastapi/fastapi/pull/12406.
+
+This workaround should be removed when FastAPI had several new releases with the fix.
+"""
+
+
+def get_hx_request(
+    request: Request, hx_request: Annotated[str | None, Header()] = None
+) -> RequestAlias | None:
     """
     FastAPI dependency that returns the current request if it is an HTMX one,
     i.e. it contains an `"HX-Request: true"` header.
@@ -11,5 +24,20 @@ def get_hx_request(request: Request, hx_request: Annotated[str | None, Header()]
     return request if hx_request == "true" else None
 
 
-DependsHXRequest = Annotated[Request | None, Depends(get_hx_request)]
+def get_page_request(request: Request) -> RequestAlias:
+    """
+    Replacement dependency for `Request` to work around this FastAPI bug:
+    https://github.com/fastapi/fastapi/discussions/12403.
+    """
+    return request
+
+
+DependsHXRequest = Annotated[RequestAlias | None, Depends(get_hx_request)]
 """Annotated type (dependency) for `get_hx_request()` for FastAPI."""
+
+DependsPageRequest = Annotated[RequestAlias, Depends(get_page_request)]
+"""
+Annotated `Request` dependency alias.
+
+Workaround for this FastAPI bug: https://github.com/fastapi/fastapi/discussions/12403
+"""

--- a/fasthx/dependencies.py
+++ b/fasthx/dependencies.py
@@ -32,10 +32,10 @@ def get_page_request(request: Request) -> RequestAlias:
     return request
 
 
-DependsHXRequest = Annotated[RequestAlias | None, Depends(get_hx_request)]
+DependsHXRequest = Annotated[RequestAlias | Request | None, Depends(get_hx_request)]
 """Annotated type (dependency) for `get_hx_request()` for FastAPI."""
 
-DependsPageRequest = Annotated[RequestAlias, Depends(get_page_request)]
+DependsPageRequest = Annotated[RequestAlias | Request, Depends(get_page_request)]
 """
 Annotated `Request` dependency alias.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fasthx"
-version = "2.0.0"
+version = "2.0.1"
 description = "FastAPI data APIs with HTMX support."
 authors = ["Peter Volf <do.volfp@gmail.com>"]
 readme = "README.md"

--- a/tests/test_core_decorators.py
+++ b/tests/test_core_decorators.py
@@ -41,12 +41,19 @@ def hx_app() -> FastAPI:  # noqa: C901
 
     @app.get("/")
     @page(render_user_list)
-    def index(random_number: DependsRandomNumber) -> list[User]:
+    def index(
+        request: Request,  # Testing workaround for FastAPI bug. https://github.com/fastapi/fastapi/pull/12406
+        random_number: DependsRandomNumber,
+    ) -> list[User]:
         return users
 
     @app.get("/htmx-or-data")
     @hx(render_user_list)
-    def htmx_or_data(random_number: DependsRandomNumber, response: Response) -> list[User]:
+    def htmx_or_data(
+        request: Request,  # Testing workaround for FastAPI bug. https://github.com/fastapi/fastapi/pull/12406
+        random_number: DependsRandomNumber,
+        response: Response,
+    ) -> list[User]:
         response.headers["test-header"] = "exists"
         return users
 


### PR DESCRIPTION
This PR should be reversed a few releases after FastAPI merges [this PR](https://github.com/fastapi/fastapi/pull/12406) or fixes the bug in some other way.