### PR TITLE
Modified documentation examples to encourage use of coroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ from fasthx import hx, page
 app = FastAPI()
 
 # Create a dependecy to see that its return value is available in the render function.
-def get_random_number() -> int:
+async def get_random_number() -> int:
     return 4  # Chosen by fair dice roll.
 
 DependsRandomNumber = Annotated[int, Depends(get_random_number)]
@@ -101,10 +101,10 @@ DependsRandomNumber = Annotated[int, Depends(get_random_number)]
 # Create the render methods: they must always have these three arguments.
 # If you're using static type checkers, the type hint of `result` must match
 # the return type annotation of the route on which this render method is used.
-def render_index(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
+async def render_index(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
     return "<h1>Hello FastHX</h1>"
 
-def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
+async def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
     # The value of the `DependsRandomNumber` dependency is accessible with the same name as in the route.
     random_number = context["random_number"]
     lucky_number = f"<h1>{random_number}</h1>"
@@ -113,12 +113,12 @@ def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], r
 
 @app.get("/")
 @page(render_index)
-def index() -> None:
+async def index() -> None:
     ...
 
 @app.get("/htmx-or-data")
 @hx(render_user_list)
-def htmx_or_data(random_number: DependsRandomNumber) -> list[dict[str, str]]:
+async def htmx_or_data(random_number: DependsRandomNumber) -> list[dict[str, str]]:
     return [{"name": "Joe"}]
 
 @app.get("/htmx-only")

--- a/docs/examples/custom-templating.md
+++ b/docs/examples/custom-templating.md
@@ -12,7 +12,7 @@ from fasthx import hx, page
 app = FastAPI()
 
 # Create a dependecy to see that its return value is available in the render function.
-def get_random_number() -> int:
+async def get_random_number() -> int:
     return 4  # Chosen by fair dice roll.
 
 DependsRandomNumber = Annotated[int, Depends(get_random_number)]
@@ -20,10 +20,10 @@ DependsRandomNumber = Annotated[int, Depends(get_random_number)]
 # Create the render methods: they must always have these three arguments.
 # If you're using static type checkers, the type hint of `result` must match
 # the return type annotation of the route on which this render method is used.
-def render_index(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
+async def render_index(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
     return "<h1>Hello FastHX</h1>"
 
-def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
+async def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
     # The value of the `DependsRandomNumber` dependency is accessible with the same name as in the route.
     random_number = context["random_number"]
     lucky_number = f"<h1>{random_number}</h1>"
@@ -32,12 +32,12 @@ def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], r
 
 @app.get("/")
 @page(render_index)
-def index() -> None:
+async def index() -> None:
     ...
 
 @app.get("/htmx-or-data")
 @hx(render_user_list)
-def htmx_or_data(random_number: DependsRandomNumber) -> list[dict[str, str]]:
+async def htmx_or_data(random_number: DependsRandomNumber) -> list[dict[str, str]]:
     return [{"name": "Joe"}]
 
 @app.get("/htmx-only")

--- a/examples/custom-rendering/custom_rendering_app.py
+++ b/examples/custom-rendering/custom_rendering_app.py
@@ -9,21 +9,21 @@ app = FastAPI()
 
 
 # Create a dependecy to see that its return value is available in the render function.
-def get_random_number() -> int:
+async def get_random_number() -> int:
     return 4  # Chosen by fair dice roll.
 
 
 DependsRandomNumber = Annotated[int, Depends(get_random_number)]
 
 
-def render_index(result: Any, *, context: dict[str, Any], request: Request) -> str:
+async def render_index(result: Any, *, context: dict[str, Any], request: Request) -> str:
     return "<h1>Hello FastHX</h1>"
 
 
 # Create the render method: it must always have these three arguments.
 # If you're using static type checkers, the type hint of `result` must match the return type
 # annotation of the route on which this render method is used.
-def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
+async def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], request: Request) -> str:
     # The value of the `DependsRandomNumber` dependency is accessible with the same name as in the route.
     random_number = context["random_number"]
     lucky_number = f"<h1>{random_number}</h1>"
@@ -35,14 +35,14 @@ def render_user_list(result: list[dict[str, str]], *, context: dict[str, Any], r
 # fastapi==0.111.0, at least on the first mypy run when there's no cache.
 @app.get("/", response_model=None, include_in_schema=False)  # type: ignore[arg-type,unused-ignore]
 @page(render_index)
-def index() -> None: ...
+async def index() -> None: ...
 
 
 # Note on the type ignore: it seems mypy generic resolution fails at
 # fastapi==0.111.0, at least on the first mypy run when there's no cache.
 @app.get("/htmx-or-data")  # type: ignore[arg-type,unused-ignore]
 @hx(render_user_list)
-def htmx_or_data(random_number: DependsRandomNumber, response: Response) -> list[dict[str, str]]:
+async def htmx_or_data(random_number: DependsRandomNumber, response: Response) -> list[dict[str, str]]:
     response.headers["my-response-header"] = "works"
     return [{"name": "Joe"}]
 


### PR DESCRIPTION
I changed the examples to utilize async functions to encourage usage of the event loop rather than running non-blocking tasks in the thread pool. Biasing toward coroutines for routes, renderers, and even dependencies (`Depends()`) avoids overhead for smaller tasks and reduces contention for thread resources for important tasks to make use of it. This is cautioned here [FastAPI Tips](https://github.com/Kludex/fastapi-tips?tab=readme-ov-file#101-fastapi-tips-by-the-fastapi-expert) and here [FastAPI Concurrency](https://fastapi.tiangolo.com/async/?h=async#very-technical-details) Just encouraging good practices 👍.