### PR TITLE
Pydantic >=2.11 compat: get `model_computed_fields` from model class

### DIFF
--- a/fasthx/jinja.py
+++ b/fasthx/jinja.py
@@ -70,8 +70,11 @@ class JinjaContext:
         if hasattr(obj, "__dict__"):
             # Covers Pydantic models and standard classes.
             object_keys = obj.__dict__.keys()
-            if hasattr(obj, "model_computed_fields"):  # Pydantic computed fields support.
-                object_keys = [*(() if object_keys is None else object_keys), *obj.model_computed_fields]
+            if hasattr(type(obj), "model_computed_fields"):  # Pydantic computed fields support.
+                object_keys = [
+                    *(() if object_keys is None else object_keys),
+                    *type(obj).model_computed_fields,
+                ]
         elif hasattr(obj, "__slots__"):
             # Covers classes with with __slots__.
             object_keys = obj.__slots__

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 import pytest
@@ -293,5 +294,7 @@ class TestJinjaContext:
             def random_number(self) -> int:
                 return 4
 
-        context = JinjaContext.unpack_object(Model(name="Eric"))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            context = JinjaContext.unpack_object(Model(name="Eric"))
         assert context == {"name": "Eric", "random_number": 4}


### PR DESCRIPTION
Hello! First of all thanks for this, i *love it.*

Updated to [pydantic 2.11](https://pydantic.dev/articles/pydantic-v2-11-release) and started seeing some warnings for how accessing `model_fields` and `model_computed_fields` from the model instance is deprecated, and one should instead access it from the class. This has been supported in all cases where one can access it from the instance, i believe, so it should be backwards compatible.

Anyway, really appreciate this package, here's me trying to help out with the chores.