### PR TITLE
Add Python in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,20 @@
 
 **Documentation and examples**: [https://volfpeter.github.io/fasthx](https://volfpeter.github.io/fasthx/)
 
-# FastHX - Python, FastAPI, and HTMX
+# FastHX
 
-Python FastAPI server-side rendering with built-in HTMX support.
+Python server-side rendering library for FastAPI with built-in HTMX support.
+
+FastHX simplifies building interactive web applications with FastAPI and hypermedia frameworks like HTMX.
 
 For an even deeper FastAPI integration and a Next.js-like developer experience, you should check out [holm](https://volfpeter.github.io/holm/).
 
 ## Key features
 
-- **Decorator syntax** that works with FastAPI as one would expect, no need for unused or magic dependencies in routes.
+- **Python decorator syntax** that works with FastAPI as one would expect, no need for unused or magic dependencies in routes.
 - Built for **HTMX**, but can be used without it.
-- Works with **any templating engine** or server-side rendering library, e.g. `htmy`, `jinja2`, or `dominate`.
+- Works with **any Python templating engine** or server-side rendering library, e.g. `htmy`, `jinja2`, or `dominate`.
 - Supports async **HTML streaming** for optimal time to first byte and first contentful paint.
-- Gives the rendering engine **access to all dependencies** of the decorated route.
-- HTMX **routes work as expected** if they receive non-HTMX requests, so the same route can serve data and render HTML at the same time.
-- **Response headers** you set in your routes are kept after rendering, as you would expect in FastAPI.
-- **Correct typing** makes it possible to apply other (typed) decorators to your routes.
-- Works with both **sync** and **async routes**.
 
 ## Testimonials
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ For an even deeper FastAPI integration and a Next.js-like developer experience, 
 - Built for **HTMX**, but can be used without it.
 - Works with **any Python templating engine** or server-side rendering library, e.g. `htmy`, `jinja2`, or `dominate`.
 - Supports async **HTML streaming** for optimal time to first byte and first contentful paint.
+- Gives the rendering engine **access to all dependencies** of the decorated route.
+- HTMX **routes work as expected** if they receive non-HTMX requests, so the same route can serve data and render HTML at the same time.
+- **Response headers** you set in your routes are kept after rendering, as you would expect in FastAPI.
+- **Correct typing** makes it possible to apply other (typed) decorators to your routes.
+- Works with both **sync** and **async routes**.
 
 ## Testimonials
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 **Documentation and examples**: [https://volfpeter.github.io/fasthx](https://volfpeter.github.io/fasthx/)
 
-# FastHX
+# FastHX - Python, FastAPI, and HTMX
 
-FastAPI server-side rendering with built-in HTMX support.
+Python FastAPI server-side rendering with built-in HTMX support.
 
 For an even deeper FastAPI integration and a Next.js-like developer experience, you should check out [holm](https://volfpeter.github.io/holm/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,11 @@ For an even deeper FastAPI integration and a Next.js-like developer experience, 
 - Built for **HTMX**, but can be used without it.
 - Works with **any Python templating engine** or server-side rendering library, e.g. `htmy`, `jinja2`, or `dominate`.
 - Supports async **HTML streaming** for optimal time to first byte and first contentful paint.
+- Gives the rendering engine **access to all dependencies** of the decorated route.
+- HTMX **routes work as expected** if they receive non-HTMX requests, so the same route can serve data and render HTML at the same time.
+- **Response headers** you set in your routes are kept after rendering, as you would expect in FastAPI.
+- **Correct typing** makes it possible to apply other (typed) decorators to your routes.
+- Works with both **sync** and **async routes**.
 
 ## Testimonials
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,21 +9,18 @@
 
 # FastHX
 
-FastAPI server-side rendering with built-in HTMX support.
+Python server-side rendering library for FastAPI with built-in HTMX support.
+
+FastHX simplifies building interactive web applications with FastAPI and hypermedia frameworks like HTMX.
 
 For an even deeper FastAPI integration and a Next.js-like developer experience, you should check out [holm](https://volfpeter.github.io/holm/).
 
 ## Key features
 
-- **Decorator syntax** that works with FastAPI as one would expect, no need for unused or magic dependencies in routes.
+- **Python decorator syntax** that works with FastAPI as one would expect, no need for unused or magic dependencies in routes.
 - Built for **HTMX**, but can be used without it.
-- Works with **any templating engine** or server-side rendering library, e.g. `htmy`, `jinja2`, or `dominate`.
+- Works with **any Python templating engine** or server-side rendering library, e.g. `htmy`, `jinja2`, or `dominate`.
 - Supports async **HTML streaming** for optimal time to first byte and first contentful paint.
-- Gives the rendering engine **access to all dependencies** of the decorated route.
-- HTMX **routes work as expected** if they receive non-HTMX requests, so the same route can serve data and render HTML at the same time.
-- **Response headers** you set in your routes are kept after rendering, as you would expect in FastAPI.
-- **Correct typing** makes it possible to apply other (typed) decorators to your routes.
-- Works with both **sync** and **async routes**.
 
 ## Testimonials
 


### PR DESCRIPTION
- Fixes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified project description to emphasize Python server-side rendering with FastAPI and built-in HTMX support.
  * Updated wording to specify Python decorator syntax and compatibility with any Python templating engine (examples updated for clarity).
  * Minor phrasing improvements to better describe how the library simplifies building interactive FastAPI apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->