### PR TITLE
refactor: use inspect.iscoroutinefunction instead of asyncio.iscoroutinefunction

### DIFF
--- a/fasthx/utils.py
+++ b/fasthx/utils.py
@@ -1,5 +1,4 @@
 import inspect
-from asyncio import iscoroutinefunction
 from collections.abc import Callable, Mapping
 from typing import Any, cast
 
@@ -56,7 +55,7 @@ async def execute_maybe_sync_func(func: MaybeAsyncFunc[P, T], *args: P.args, **k
         *args: Positional arguments to pass to the function.
         **kwargs: Keyword arguments to pass to the function.
     """
-    if iscoroutinefunction(func):
+    if inspect.iscoroutinefunction(func):
         return await func(*args, **kwargs)  # type: ignore[no-any-return]
 
     return await run_in_threadpool(cast(Callable[P, T], func), *args, **kwargs)


### PR DESCRIPTION
## Summary
- Replace `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in `fasthx/utils.py`
- Remove the now-unused `from asyncio import iscoroutinefunction` import
- The `inspect` module was already imported, so this consolidates imports and removes a redundant one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated async function detection mechanism for improved reliability in async operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->