### PR TITLE
Remove unsupported zensical theme name to fix docs

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -3,7 +3,6 @@ repo_name: volfpeter/fasthx
 repo_url: https://github.com/volfpeter/fasthx
 
 theme:
-  name: modern
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation site configuration, with a small change to the theme setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->