### PR TITLE
Lazy import jinja2 in the htmy integration

### DIFF
--- a/fasthx/__init__.py
+++ b/fasthx/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 from .component_selectors import ComponentHeader as ComponentHeader
 from .core_decorators import hx as hx

--- a/fasthx/htmy.py
+++ b/fasthx/htmy.py
@@ -5,7 +5,6 @@ from dataclasses import KW_ONLY, dataclass, field
 from typing import TYPE_CHECKING, Any, TypeAlias, overload
 
 from fastapi import Request
-from fastapi.templating import Jinja2Templates
 from htmy import Component, Context, Renderer
 from htmy.jinja import JinjaTemplate as _JinjaTemplate
 from htmy.jinja import JinjaTemplates
@@ -127,6 +126,10 @@ class JinjaTemplate(_JinjaTemplate):
     __slots__ = ()
 
     def _build_context(self, htmy_context: Context) -> dict[str, Any]:
+        # This imports the entire jinja2 library if installed.
+        # Do it lazily so the import is not attempted when someone imports from this module.
+        from fastapi.templating import Jinja2Templates
+
         result = super()._build_context(htmy_context)
 
         request: Request = CurrentRequest.from_context(htmy_context)


### PR DESCRIPTION
Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for environments where optional template-related components are unavailable unless actively used.

* **Chores**
  * Updated the package version to 3.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->