### PR TITLE
fix: pass the actual route params dict to jinja contexts as route_params

### DIFF
--- a/fasthx/__init__.py
+++ b/fasthx/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
 from .component_selectors import ComponentHeader as ComponentHeader
 from .core_decorators import hx as hx

--- a/fasthx/htmy.py
+++ b/fasthx/htmy.py
@@ -134,7 +134,7 @@ class JinjaTemplate(_JinjaTemplate):
 
         request: Request = CurrentRequest.from_context(htmy_context)
         result.setdefault("request", request)
-        result["route_params"] = RouteParams.from_context(htmy_context)
+        result["route_params"] = RouteParams.from_context(htmy_context).params
 
         source = JinjaTemplates.from_context(htmy_context).source
         if isinstance(source, Jinja2Templates):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Template contexts now expose route parameters directly as a mapping, making them easier to access in templates.

- **Bug Fixes**
  - Improved consistency when working with route parameters in Jinja templates.

- **Chores**
  - Updated the package version to 3.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->